### PR TITLE
Attempt to also improve closure input section clarity

### DIFF
--- a/examples/fn/closures/input_parameters/input.md
+++ b/examples/fn/closures/input_parameters/input.md
@@ -1,21 +1,19 @@
 While Rust chooses how to capture variables on the fly mostly without 
-annotation, this ambiguity is not allowed when writing functions. When 
-taking a closure as an input parameter, Rust will preferentially capture 
-variables in the least restrictive manner possible on a variable-by-variable 
-basis.
+annotation, this ambiguity is not allowed when writing functions. The
+closure's complete type must be annotated via one of the following `traits`:
 
-A closure's complete type must be annotated, including the captured type, as 
-one of the following `traits`:
+* `Fn`: the closure *may* capture by reference (`&T`)
+* `FnMut`: the closure additionally *may* capture by mutable reference (`&mut T`)
+* `FnOnce`: the closure additionally *may* capture by value (`T`)
 
-* `Fn`: the closure takes capture by reference (`&T`)
-* `FnMut`: the closure takes capture by mutable reference (`&mut T`)
-* `FnOnce`: the closure takes capture by value (`T`)
+These `traits` while strict, leave Rust some flexibility. Rust will preferentially
+capture variables in the least restrictive manner possible on a
+variable-by-variable basis.
 
-Even annotated, these are very flexible: a parameter of `FnOnce` specifies
-the closure *may* capture by `T`, `&mut T`, or `&T` at will. This is because  
-if a move is possible, then any type of borrow should also be possible. The 
-reverse is not true: if the parameter is `Fn`, then nothing lower on the 
-list is allowed. 
+Consider a parameter of `FnOnce`: this specifies the closure *may* capture by `T`,
+`&mut T`, or `&T` at will. This is because if a move is possible, then any type of
+borrow should also be possible. The reverse is not true: if the parameter is `Fn`,
+then nothing lower on the list is allowed. 
 
 In the following example, try swapping the usage of `Fn`, `FnMut`, and 
 `FnOnce` to see what happens:


### PR DESCRIPTION
I liked some of your changes but others I wasn't sure about. I tried to make comments on the PR but I found it was awkward. In particular, I thought that the ambiguity at the top basically went unspecified and I thought it was kinda odd that it wasn't explained until after the bullet points. I also tried to be more up front about how captures may happen as discussed in the issue.

I liked that you moved the flexibility part really early to help point that out earlier to the reader but found that I thought that it got in the way of stating that functions need to be specific. I think I ended up somewhere in between the two. The last two paragraphs might be able to be merged or something. Not sure.

What do you think?
